### PR TITLE
Fix an issue leading to the optimal hyperparameter set not being selected.

### DIFF
--- a/R/HyperparameterOptimisation.R
+++ b/R/HyperparameterOptimisation.R
@@ -1332,7 +1332,7 @@ hpo.get_best_parameter_set <- function(optimisation_score_table, n=1L, acquisiti
                                                        method=acquisition_function)
   
   # Sort by decreasing optimisation score.
-  summary_table[order(-optimisation_score)]
+  summary_table <- summary_table[order(-optimisation_score)]
   
   # Average objective score over known available in the score table.
   best_parameter_data <- head(summary_table, n=n)


### PR DESCRIPTION
This fixes an issue that causes optimal hyperparameter sets not being selected. This is because the table was ordered in-place by the optimisation_score, but these changes were not propagated further.